### PR TITLE
Remove extraneous comma

### DIFF
--- a/thanks/thanks.py
+++ b/thanks/thanks.py
@@ -40,6 +40,6 @@ def find_package_roles(requirements_file):
                         colored(contributor, 'blue'),
                         colored(",".join(give_thanks_to[contributor]['packages']), 'red'),
                         colored(give_thanks_to[contributor]['url'], 'green'),
-                    ),
+                    )
                 )
             print("\n")


### PR DESCRIPTION
Because of the trailing comma, `print` prints out a tuple, which breaks
coloring.